### PR TITLE
Nuke new writenode settings

### DIFF
--- a/env/includes/app_locations.yml
+++ b/env/includes/app_locations.yml
@@ -164,7 +164,7 @@ apps.tk-nuke-writenode.location:
   type: shotgun
   entity_type: *ToolkitComponent
   field: sg_uploaded_app
-  version: 635 #tk-nuke-writenode-1.4.2-niho.1
+  version: 748 #tk-nuke-writenode-1.4.2-niho.2
   ## Dev
   # type: dev
   # path: ~/Desktop/github/tk-nuke-writenode-niho

--- a/env/includes/settings/tk-nuke-writenode.yml
+++ b/env/includes/settings/tk-nuke-writenode.yml
@@ -118,7 +118,7 @@ settings.tk-nuke-writenode.shot:
     proxy_publish_template:
     proxy_render_template:
     render_template: nuke_shot_render_movie
-    publish_template:
+    publish_template: nuke_shot_render_movie
     settings:
       mov64_codec: ADvn
       mov64_dnxhd_codec_profile: "DNxHD 422 8-bit 36Mbit"

--- a/env/includes/settings/tk-nuke-writenode.yml
+++ b/env/includes/settings/tk-nuke-writenode.yml
@@ -112,9 +112,24 @@ settings.tk-nuke-writenode.shot:
   template_script_work: nuke_shot_work
   show_convert_actions: True
   write_nodes:
+  - file_type: mov
+    name: review qt
+    promote_write_knobs: [mov64_dnxhd_codec_profile, mov64_fps]
+    proxy_publish_template:
+    proxy_render_template:
+    render_template: nuke_shot_render_movie
+    publish_template:
+    settings:
+      mov64_codec: ADvn
+      mov64_dnxhd_codec_profile: "DNxHD 422 8-bit 36Mbit"
+      mov64_fps: 23.976
+      mov64_write_timecode: True
+      channels: rgb
+    tank_type: Rendered Movie
+    tile_color: []
   - file_type: exr
     name: main output
-    promote_write_knobs: []
+    promote_write_knobs: [compression]
     proxy_publish_template:
     proxy_render_template:
     render_template: nuke_shot_main_work

--- a/env/includes/settings/tk-nuke-writenode.yml
+++ b/env/includes/settings/tk-nuke-writenode.yml
@@ -137,7 +137,7 @@ settings.tk-nuke-writenode.shot:
     settings:
       autocrop: False
       channels: rgb
-      compression: DWAB
+      compression: "Zip (1 scanline)"
       dw_compression_level: 20
       datatype: 16 bit half
       metadata: all metadata


### PR DESCRIPTION
- new tk-nuke-writenode version (made SEQ optional in path template)
- new 'review qt' write node
- changed 'main output' to zip1 scanline, and promoted compression knob so we can change as needed per project